### PR TITLE
Fix for broken PhysX Workflow doc link

### DIFF
--- a/testing-guidance/workflow-tests/physics/physics-ragdoll-workflows.md
+++ b/testing-guidance/workflow-tests/physics/physics-ragdoll-workflows.md
@@ -5,8 +5,10 @@ Testing in this area should focus on the new Ragdoll Authoring Improvements.
 ## General Docs
 
 * [Animation Editor User Interface](https://www.o3de.org/docs/user-guide/visualization/animation/animation-editor/user-interface/)
-* [Creating and Simulating a PhysX Ragdoll](https://www.o3de.org/docs/user-guide/visualization/animation/animation-editor/creating-and-simulating-physx-ragdoll/)
-* [Setting up a Ragdoll](https://stabilization-22-10--o3deorg.netlify.app/docs/user-guide/visualization/animation/animation-editor/ragdoll/ragdoll-physics-setup/)
+* [PhysX Ragdoll](https://www.o3de.org/docs/user-guide/visualization/animation/animation-editor/ragdoll/)
+* [PhysX Ragdoll Setup](https://www.o3de.org/docs/user-guide/visualization/animation/animation-editor/ragdoll/ragdoll-physics-setup/)
+* [PhysX Ragdoll Animation Graph](https://www.o3de.org/docs/user-guide/visualization/animation/animation-editor/ragdoll/ragdoll-adding-to-animation-graph/)
+* [PhysX Ragdoll Editor Simulation](https://www.o3de.org/docs/user-guide/visualization/animation/animation-editor/ragdoll/ragdoll-simulating-in-editor/)
 
 ## Common Issues to Watch For
 


### PR DESCRIPTION
This fixes o3de/sig-simulation#50.

Original Doc was broken up between 3 new docs when system changed.